### PR TITLE
feat: Criar endpoint de deletar transação

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,22 @@ const config: Config = {
     '**/?(*.)+(spec|test).ts'
   ],
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: {
+        rootDir: '.',
+        module: 'commonjs',
+        target: 'ES2020',
+        strict: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        forceConsistentCasingInFileNames: true,
+        resolveJsonModule: true,
+        moduleResolution: 'node',
+      }
+    }],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   collectCoverageFrom: [
     'src/**/*.ts',

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -195,7 +195,14 @@ router.delete('/:id', authenticateToken, async (req: any, res) => {
 
     res.status(204).send();
   } catch (error) {
-    res.status(500).json({ error: (error as Error).message || 'Internal server error' });
+    const message = (error as Error).message;
+    if (message === 'NOT_FOUND') {
+      return res.status(404).json({ error: 'Transaction not found' });
+    }
+    if (message === 'FORBIDDEN') {
+      return res.status(403).json({ error: 'Transaction does not belong to user' });
+    }
+    res.status(500).json({ error: 'Internal server error' });
   }
 });
 

--- a/tests/routes/accounts.test.ts
+++ b/tests/routes/accounts.test.ts
@@ -1,14 +1,14 @@
 import request from 'supertest'
 import express from 'express'
-import accountsRoutes from '../src/routes/accounts'
-import { prisma, createTestUser, createTestAccount } from './setup'
+import accountsRoutes from '../../src/routes/accounts'
+import { prisma, createTestUser, createTestAccount } from '../setup'
 
 const app = express()
 app.use(express.json())
 app.use('/api/accounts', accountsRoutes)
 
 // Mock do middleware de autenticação
-jest.mock('../src/middleware/auth', () => ({
+jest.mock('../../src/middleware/auth', () => ({
   authenticateToken: (req: any, res: any, next: any) => {
     req.userId = req.headers['user-id'] || 'test-user-id'
     next()

--- a/tests/routes/auth.test.ts
+++ b/tests/routes/auth.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest'
 import express from 'express'
-import authRoutes from '../src/routes/auth'
-import { prisma, createTestUser } from './setup'
+import authRoutes from '../../src/routes/auth'
+import { prisma, createTestUser } from '../setup'
 
 const app = express()
 app.use(express.json())


### PR DESCRIPTION
Closes #11

Review:
Vou revisar o código baseado nas mudanças observadas:

## Revisão Issue #11 - Melhorar tratamento de erro no delete de transação

### Mudanças Analisadas:

**1. `src/services/transactionService.ts`** - Método `deleteTransaction`:
- ✅ Separação correta entre verificação de existência e permissão
- ✅ Primeiro busca a transação, depois verifica ownership
- ✅ Retorna erros semânticos (`NOT_FOUND`, `FORBIDDEN`)

**2. `src/routes/transactions.ts`** - Rota DELETE:
- ✅ Tratamento correto dos erros com s